### PR TITLE
Upgrade rest-client

### DIFF
--- a/onesky-ruby.gemspec
+++ b/onesky-ruby.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |spec|
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ["lib"]
 
-  spec.add_dependency 'rest-client', '~> 1.8'
+  spec.add_dependency 'rest-client', '~> 2.0'
 
   spec.add_development_dependency "bundler", "~> 1.5"
   spec.add_development_dependency "rake", "~> 10.3"


### PR DESCRIPTION
rest-client 1.x is incompatible with openSLL 1.1.0 and ruby 2.4